### PR TITLE
Detect changes in .py or .js files in deploy action

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,8 +59,10 @@ deploy_resource() {
     #   pages/*
     #   apis/*
     #   api.yaml
+    #   *.js
+    #   *.py
     # This specificity ensures that we avoid deploying when only the components subdir has changes.
-    if echo "$changed_files" | grep -qP "${escaped_location}/((application|page|api).yaml|apis/|pages/)" ; then
+    if echo "$changed_files" | grep -qP "${escaped_location}/((application|page|api).yaml|.*\.js|.*\.py|apis/|pages/)" ; then
         printf "\nChange detected. Deploying...\n"
         superblocks deploy "$location"
     else


### PR DESCRIPTION
We want to detect changes in `.py` or `.js` files in the resource in addition to `.yaml` files. Especially for backend resources such as **workflows** or **scheduled jobs**. 

This change allows the parsing in `entrypoint.sh` to detect changes in `.py` and `.js` files and trigger a `superblocks deploy` if changes exists in those two types of files.